### PR TITLE
True semitransparency during `uncover`

### DIFF
--- a/logic.typ
+++ b/logic.typ
@@ -39,9 +39,9 @@
   })
 }
 
-// 50% alpha
-#let cover-with-white-rect = cover-with-rect.with(fill: "fff8")
-#let cover-with-black-rect = cover-with-rect.with(fill: "0008")
+// matches equivalent transparency of "gray.lighten(50%)"
+#let cover-with-white-rect = cover-with-rect.with(fill: rgb(255, 255, 255, 213))
+#let cover-with-black-rect = cover-with-rect.with(fill: rgb(0, 0, 0, 213))
 
 // States are normally defined at the top of the file by convention, but functions aren't
 // hoisted. So wait to populate the state until here, when functions are accessible

--- a/logic.typ
+++ b/logic.typ
@@ -6,7 +6,7 @@
 
 #let enable-handout-mode(flag) = handout-mode.update(flag)
 
-#let cover-with-rect(outset: 0em, fill: auto, body) = {
+#let cover-with-rect(..cover-args, fill: auto, body) = {
   if fill == auto {
     panic(
       "`auto` fill value is not supported until typst provides utilities to"
@@ -23,15 +23,17 @@
       let body-size = measure(body, styles)
       let bounding-width = calc.min(body-size.width, layout-size.width)
       let wrapped-body-size = measure(box(body, width: bounding-width), styles)
+      let named = cover-args.named()
+      if "width" not in named {
+        named.insert("width", wrapped-body-size.width)
+      }
+      if "height" not in named {
+        named.insert("height", wrapped-body-size.height)
+      }
       stack(
         spacing: -wrapped-body-size.height,
         box(body),
-        rect(
-          fill: fill,
-          width: wrapped-body-size.width,
-          height: wrapped-body-size.height,
-          outset: outset,
-        )
+        rect(fill: fill, ..named, ..cover-args.pos())
       )
     })
   })

--- a/logic.typ
+++ b/logic.typ
@@ -53,7 +53,7 @@
     // considering prior "transparent" behavior is broken in those cases anyway
     "transparent": cover-with-white-rect,
     "transparent-black": cover-with-black-rect,
-    "default": hide
+    "default": hide,
   )
 )
 
@@ -68,6 +68,10 @@
   let mode-key = mode
   if mode == auto {
     mode-key = "default"
+  }
+  if type(mode) == "function" {
+    // skip mode lookup, user directly provided hider function
+    return mode(body)
   }
   locate(loc => {
     let hider-options = content-hider-modes.at(loc)

--- a/logic.typ
+++ b/logic.typ
@@ -17,7 +17,8 @@
     fill = rgb(fill)
   }
 
-  layout(layout-size => {
+  // The extra `box` allows inline content to remain inline after being covered
+  box(layout(layout-size => {
     set text(top-edge: "bounds", bottom-edge: "bounds")
     style(styles => {
       let body-size = measure(body, styles)
@@ -32,11 +33,11 @@
       }
       stack(
         spacing: -wrapped-body-size.height,
-        box(body),
+        body,
         rect(fill: fill, ..named, ..cover-args.pos())
       )
     })
-  })
+  }))
 }
 
 // matches equivalent transparency of "gray.lighten(50%)"

--- a/logic.typ
+++ b/logic.typ
@@ -51,7 +51,11 @@
 
 // matches equivalent transparency of "gray.lighten(50%)"
 #let cover-with-white-rect = cover-with-rect.with(fill: rgb(255, 255, 255, 213))
-#let cover-with-black-rect = cover-with-rect.with(fill: rgb(0, 0, 0, 213))
+// White cover was determined using a color picker over `gray.lighten(50%)`. Black cover
+// could theoretically be the *inverse* of this value (i.e., if white uses 213,
+// black can use 255 - 213 = 42), but in practice this leaves text too visible.
+// Using 127 more closely matches the visual contrast from the `white` variant.
+#let cover-with-black-rect = cover-with-rect.with(fill: rgb(0, 0, 0, 127))
 
 // States are normally defined at the top of the file by convention, but functions aren't
 // hoisted. So wait to populate the state until here, when functions are accessible

--- a/logic.typ
+++ b/logic.typ
@@ -19,7 +19,6 @@
 
   // The extra `box` allows inline content to remain inline after being covered
   box(layout(layout-size => {
-    set text(top-edge: "bounds", bottom-edge: "bounds")
     style(styles => {
       let body-size = measure(body, styles)
       let bounding-width = calc.min(body-size.width, layout-size.width)
@@ -30,6 +29,16 @@
       }
       if "height" not in named {
         named.insert("height", wrapped-body-size.height)
+      }
+      if "outset" not in named {
+        // This outset covers the tops of tall letters and the bottoms of letters with
+        // descenders. Alternatively, we could use
+        // `set text(top-edge: "bounds", bottom-edge: "bounds")` to get the same effect,
+        // but this changes text alignment and also misaligns bullets in enums/lists.
+        // In contrast, `outset` preserves spacing and alignment at the cost of adding
+        // a slight, visible border when the covered object is right next to the edge
+        // of a color change.
+        named.insert("outset", (top: 0.15em, bottom: 0.25em))
       }
       stack(
         spacing: -wrapped-body-size.height,

--- a/logic.typ
+++ b/logic.typ
@@ -6,7 +6,7 @@
 
 #let enable-handout-mode(flag) = handout-mode.update(flag)
 
-#let cover-with-rect(..cover-args, fill: auto, body) = {
+#let cover-with-rect(..cover-args, fill: auto, inline: true, body) = {
   if fill == auto {
     panic(
       "`auto` fill value is not supported until typst provides utilities to"
@@ -17,8 +17,7 @@
     fill = rgb(fill)
   }
 
-  // The extra `box` allows inline content to remain inline after being covered
-  box(layout(layout-size => {
+  let to-display = layout(layout-size => {
     style(styles => {
       let body-size = measure(body, styles)
       let bounding-width = calc.min(body-size.width, layout-size.width)
@@ -46,7 +45,12 @@
         rect(fill: fill, ..named, ..cover-args.pos())
       )
     })
-  }))
+  })
+  if inline {
+    box(to-display)
+  } else {
+    to-display
+  }
 }
 
 // matches equivalent transparency of "gray.lighten(50%)"

--- a/polylux.typ
+++ b/polylux.typ
@@ -1,5 +1,5 @@
 #import "themes/themes.typ"
 #import "logic.typ"
-#import "logic.typ": polylux-slide, uncover, only, alternatives, alternatives-match, alternatives-fn, alternatives-cases, one-by-one, line-by-line, list-one-by-one, enum-one-by-one, terms-one-by-one, pause, enable-handout-mode
+#import "logic.typ": polylux-slide, uncover, cover-with-rect, add-hider-mode, only, alternatives, alternatives-match, alternatives-fn, alternatives-cases, one-by-one, line-by-line, list-one-by-one, enum-one-by-one, terms-one-by-one, pause, enable-handout-mode
 #import "utils/utils.typ"
 #import "utils/utils.typ": polylux-outline, fit-to-height, side-by-side, pdfpc


### PR DESCRIPTION
Fix #17 by providing a more generalized cover function. Works with several content types (not just text) and on several background colors instead of assuming white. Sample usage:


<details>

```typst
#import "polylux.typ": *

#set page(width: 2in, height: 2.2in, background: rect(width: 100%, height: 100%))

#let slide = polylux-slide

#let img = image("assets/logo.png", height: 0.5in)


#slide[
  = Hello, world

  #uncover(2, mode: "transparent", img)

  #set text(fill: white)
  #let bg(fill, h: 45%) = place(rect(width: 100%, height: h, fill: fill))

  // Typst `green` is not true green
  #add-hider-mode("green", cover-with-rect.with(fill: rgb(46, 204, 64, 90%)))
  // Use "transparent" on black background as default when no
  // mode is specified
  #add-hider-mode("default", logic.cover-with-black-rect)
  #bg(black)
  #uncover(2, [Some text])
  #side-by-side[
    #uncover(2, img)
  ][
    // Let the user specify their own modes when operating on nonstandard background
    // colors
    #uncover(2, mode: "green", box(img, fill: green, outset: 1em))
  ]
]
```
</details>

Produces:
![image](https://github.com/andreasKroepelin/polylux/assets/23620506/e028960d-2bd7-4c73-b68e-11a970b1380f)


