### PR TITLE
Hide list markers and enum numbers

### DIFF
--- a/logic.typ
+++ b/logic.typ
@@ -292,6 +292,15 @@
 
   pdfpc-slide-markers(1)
 
+  // Workaround for typst showing list ticks and enum numbers when it should not.
+  // See https://github.com/andreasKroepelin/polylux/issues/186
+  show hide: it => {
+    set list(marker: none)
+    set enum(numbering: n => [])
+
+    it
+  }
+
   body
 
   subslide.step()

--- a/logic.typ
+++ b/logic.typ
@@ -296,7 +296,7 @@
   // See https://github.com/andreasKroepelin/polylux/issues/186
   show hide: it => {
     set list(marker: none)
-    set enum(numbering: n => [])
+    set enum(numbering: n => none)
 
     it
   }


### PR DESCRIPTION
Fixes #186

I currently cannot test this change, as `pause` is still broken on main,
see https://github.com/andreasKroepelin/polylux/issues/188#issuecomment-2470332742