### PR TITLE
Fix hidden list items taking up more space than visible ones

### DIFF
--- a/logic.typ
+++ b/logic.typ
@@ -271,9 +271,19 @@
 
   // Workaround for typst showing list ticks and enum numbers when it should not.
   // See https://github.com/andreasKroepelin/polylux/issues/186
+  let no-par-spacing(it) = (
+    context {
+      set par(spacing: par.leading)
+      it
+    }
+  )
+
+  show list: no-par-spacing
+  show enum: no-par-spacing
+
   show hide: it => {
-    set list(marker: none)
-    set enum(numbering: n => none)
+    show list.item: list
+    show enum.item: enum
 
     it
   }


### PR DESCRIPTION
Fixes a bug introduced in #190

While #190 seems to work fine at first, I have learned that it introduced a bug:
Hidden list/enum items take up more space than their visible counterpart, leading to layout shifts in
content following a list with pauses within.

The old show rule looks as follows:
```typ
#show hide: it => {
  set list(marker: none)
  set enum(numbering: n => none)
  it
}
```
As far as I now understand it, this does not work as expected.
To demonstrate this, one can replace `none` in this show rule with any arbitrary content, and observe that the output does not change.

My current understanding is that this show rule, applied to list items, changes the document structure in such a way to incidentally produce the "expected" result. Let me illustrate:

The following Typst code
```typst
- foo #pause
- bar #pause
- baz
```
Would produce roughly this element hierarchy in handout mode:
```
list
- list.item
- list.item
- list.item
```
And this one without handout mode:
```
list
- list.item
- hide
  - list.item
- hide
  - list.item
```
I *think* this show rule then does the following:
```
list
- list.item
- hide
  - list
    - list.item
- hide
  - list
    - list.item
```
... because we are changing how `list` is displayed, inside a `list.item`.

By doing this, list is actually split up into individual lists, which incidentally "fixes" the hidden list markers, wich seem to belong to the `list`, and not the `list.item`.
As a side effect of these split-up lists, the spacing between the lists is increased from paragraph `leading` to paragraph `spacing` ([link](https://typst.app/docs/reference/model/list/#parameters-tight)).

This PR changes the show rule to be less misleading:
- `show list.item: list` does exactly what the old show rule did,
  just without looking like it's doing something else entirely.
- `show list: no-par-spacing` sets `par.spacing` equal to `par.leading`,
  which makes wide and tight lists have the same spacing.
  This fixes the problem with the layout shifts, but has the side effect
  of making it more difficult to produce an actually wide list.
  If the user actually wants their list items to be far apart,
  they would have to insert `#v(1em)` or similar between list items.

This is not perfect, but it is the best solution I have found yet. This can all be reverted once list markers are properly affected by `hide`.

